### PR TITLE
Fix mkdir args

### DIFF
--- a/t/002-basic.t
+++ b/t/002-basic.t
@@ -28,7 +28,7 @@ ok $base_dir_name.IO.d, "tempdir { $base_dir_name } created";
 ok chdir($base_dir_name), "chdir ok";
 
 my $dir1 = 'dir1';
-ok mkdir 0o777, $dir1 ;
+ok mkdir $dir1, 0o777;
 
 my $zipfile = "test.zip" ;
 my $datafile = "$dir1/data123";


### PR DESCRIPTION
The form used will no longer work in Rakudo 2017.04+