### PR TITLE
Bump version and use modern META file's name

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
     "perl" : "6.*",
     "name" : "Archive::SimpleZip",
-    "version" : "0.1.1",
+    "version" : "0.1.2",
     "description" : "Write Zip Files.",
     "authors" : [ "Paul Marquess <pmqs@cpan.org" ],
     "provides" : {


### PR DESCRIPTION
Please merge AFTER https://github.com/pmqs/Archive-SimpleZip/pull/1 is merged;
the version bump is so users get that fix.

META.info is a legacy name; the modern name for the meta file is META6.json