### PR TITLE
Don't use >>.grep if .grep is enough

### DIFF
--- a/t/002-basic.t
+++ b/t/002-basic.t
@@ -311,7 +311,7 @@ subtest # List
     my $zip = SimpleZip.new($zipfile);
     isa-ok $zip, SimpleZip;
 
-    my @got = glob("gdata*")>>.grep(/5/).$zip().subst(/"gdata"/, "fred");
+    my @got = glob("gdata*").grep(/5/).$zip().subst(/"gdata"/, "fred");
 
     ok $zip.close(), "closed";
 


### PR DESCRIPTION
The use of `>>.grep` in combination with stringification is something that feels strange.  In any case, somehow the recent speedup of `>>.` (aka `nodemap`) something subtly changed so that that expression generates a `Seq` with a lot of empty `Seq`s in them, each of which stringifies to a space, and thus breaks the test.

Since I don't see a need for the `>>.` there, I'd thought it safe to remove.